### PR TITLE
[React] [Enhancement] Support custom import prefixes

### DIFF
--- a/assets/nextjs/README.md.template
+++ b/assets/nextjs/README.md.template
@@ -49,6 +49,17 @@ useEffect(() => {
 
 This is the equivalent of doing `fetch('/api/product/abc123')` but with typesafety, and you never have to remember the URL. If the API moves, the typesafe route will be updated automatically.
 
+# Configure declarative-routing
+
+After running `npx declarative-routing init`, you don't need to configure anything to use it.
+However, you may want to customize some options to change the behavior of route generation.
+
+You can edit `declarative-routing.config.json` in the root of your project. The following options are available:
+
+- `mode`: choose between `react-router`and `nextjs`. It is automatically picked on init based on the project type.
+- `routes`: the directory where the routes are defined. It is picked from the initial wizard (and defaults to `src/routes`).
+- `importPathPrefix`: the path prefix to add to the import path of the self-generated route objects, in order to be able to resolve them. It defaults to `@/app`.
+
 # When your routes change
 
 You'll need to run `{{packageManager}} dr:build` to update the generated files. This will update the types and the `@/routes` module to reflect the changes.

--- a/assets/react-router/README.md.template
+++ b/assets/react-router/README.md.template
@@ -37,6 +37,16 @@ return (
   </Home.NavLink>
 );
 ```
+# Configure declarative-routing
+
+After running `npx declarative-routing init`, you don't need to configure anything to use it.
+However, you may want to customize some options to change the behavior of route generation.
+
+You can edit `declarative-routing.config.json` in the root of your project. The following options are available:
+
+- `mode`: choose between `react-router`and `nextjs`. It is automatically picked on init based on the project type.
+- `routes`: the directory where the routes are defined. It is picked from the initial wizard (and defaults to `src/routes`).
+- `importPathPrefix`: the path prefix to add to the import path of the self-generated route objects, in order to be able to resolve them. It defaults to `@/app`.
 
 # When your routes change
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ const ConfigSchema = z.object({
       template: z.string(),
     })
     .optional(),
+    importPathPrefix: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/nextjs/build-tools.ts
+++ b/src/nextjs/build-tools.ts
@@ -97,11 +97,14 @@ async function writeRoutes(silent: boolean = false) {
   return report;
 }
 
+
 export async function parseInfoFile(fpath: string) {
   const config = getConfig();
+  const {importPathPrefix} = config;
+
 
   const newPath: RouteInfo = {
-    importPath: `@/app/${fpath}`.replace(/.ts$/, ""),
+    importPath: `${importPathPrefix || '@/app'}/${fpath}`.replace(/.ts$/, ""),
     infoPath: `/${fpath}`,
     importKey: "",
     verbs: [],

--- a/src/nextjs/build-tools.ts
+++ b/src/nextjs/build-tools.ts
@@ -97,11 +97,9 @@ async function writeRoutes(silent: boolean = false) {
   return report;
 }
 
-
 export async function parseInfoFile(fpath: string) {
   const config = getConfig();
   const {importPathPrefix} = config;
-
 
   const newPath: RouteInfo = {
     importPath: `${importPathPrefix || '@/app'}/${fpath}`.replace(/.ts$/, ""),


### PR DESCRIPTION
Makes the import prefix configurable from config file.

Example.

```ts
{
    "mode": "react-router",
    "routes": "./src/routes",
    "importPathPrefix": "@myorg/mypackage"
}
```



leads to

```ts
import * as TestRoute from "@myorg/mypackage/src/pages/Test/route.info";
```

in `routes/index.ts`
