### PR TITLE
ignore node_modules and dist on glob scan

### DIFF
--- a/src/nextjs/build-tools.ts
+++ b/src/nextjs/build-tools.ts
@@ -18,6 +18,8 @@ type RouteInfo = {
 
 const paths: Record<string, RouteInfo> = {};
 
+const ignore = ['**/node_modules/**', 'dist/**', '**/dist/**'];
+
 const VERB_KEYS: Record<string, string[]> = {
   GET: ["result"],
   POST: ["body", "result"],
@@ -194,6 +196,7 @@ export async function buildFiles(silent: boolean = false) {
     ],
     {
       cwd: config.src,
+      ignore
     }
   );
 
@@ -217,6 +220,7 @@ export async function buildFiles(silent: boolean = false) {
     ],
     {
       cwd: config.src,
+      ignore
     }
   );
 


### PR DESCRIPTION
Ignore `node_modules` and `dist` from `glob` scan.

Including those folders would lead sometimes to a result like this:

```ts
import * as NodemodulesBabelHighlightNodemodulesColorconvertRoute from "@myorg/mypackage/node_modules/@babel/highlight/node_modules/color-convert/route.info";
import * as NodemodulesColorconvertRoute from "@myorg/mypackage/node_modules/color-convert/route.info";```