### PR TITLE
Fix path generation on windows machines

### DIFF
--- a/src/nextjs/build-tools.ts
+++ b/src/nextjs/build-tools.ts
@@ -197,7 +197,8 @@ export async function buildFiles(silent: boolean = false) {
     ],
     {
       cwd: config.src,
-      ignore
+      ignore,
+      posix: true,
     }
   );
 
@@ -221,7 +222,8 @@ export async function buildFiles(silent: boolean = false) {
     ],
     {
       cwd: config.src,
-      ignore
+      ignore,
+      posix: true,
     }
   );
 


### PR DESCRIPTION
I've been trying to set this up on a NextJS project on a Windows 11 machine. I found an issue where path generation from glob was using `\\` instead of `/` for the import paths, breaking JS imports. 

Forcing glob to use posix style separators should mean the path generation will work across all platforms.