### PR TITLE
Expose route path from built route

### DIFF
--- a/assets/react-router/makeRoute.tsx
+++ b/assets/react-router/makeRoute.tsx
@@ -13,6 +13,7 @@ import {
 
 type LinkProps = Parameters<typeof Link>[0];
 type NavLinkProps = Parameters<typeof NavLink>[0];
+export type RouteBaseDefinition = RouteInfo<ZodSchema, ZodSchema>
 
 export type RouteInfo<
   Params extends z.ZodSchema,
@@ -32,6 +33,8 @@ export type RouteBuilder<
   useParams: () => z.output<Params>;
   useSearchParams: () => z.output<Search>;
   useSetSearch: () => (search?: z.input<Search>) => void;
+  title: string
+  route: string
 
   Link: React.FC<
     Omit<LinkProps, "to"> &
@@ -150,6 +153,9 @@ export function makeRoute<
     const searchString = search && queryString.stringify(search);
     return [baseUrl, searchString ? `?${searchString}` : ""].join("");
   };
+
+  routeBuilder.title = info.name
+  routeBuilder.route = route
 
   routeBuilder.useParams = function useParams(): z.output<Params> {
     const res = info.params.safeParse(useParmsRR());


### PR DESCRIPTION
This PR makes it possible to do this:

```tsx
<Route path={MyRoute.route} component={MyComponent} />
```

in React Router. Don't know if it was meant to be done in another way, and don't know if in Next this could be useful as well (I didn't replicate it to nextjs makeRoutes for this reason).

Also, it exposes route's name under title; it's a info we had in route.info that was not accessible and felt wrong, but actually I don't see any other reasons to expose it.

Little extra (ok, this should have been a separate PR, but it's a type-only, one-liner thing): I added `RouteBaseDefinition` type, to be used as a nice helper in route info compilation.

```tsx
import { z } from 'zod'
import type { RouteBaseDefinition } from '../../routes/makeRoute.tsx'

export const Route = {
  name: 'LoginRoute',
  params: z.object({}),
  search: z.object({}),
} satisfies RouteBaseDefinition
```

that helps avoiding to miss the `params` definition that would lead to an error.