### PR TITLE
[Option] Strip route prefix

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,8 @@ const ConfigSchema = z.object({
       template: z.string(),
     })
     .optional(),
-    importPathPrefix: z.string().optional(),
+  importPathPrefix: z.string().optional(),
+  stripRoutePrefix: z.string().optional(),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/nextjs/build-tools.ts
+++ b/src/nextjs/build-tools.ts
@@ -29,6 +29,13 @@ export function removeFileFromCache(fpath: string) {
   delete paths[fpath];
 }
 
+function fixPath(config: Config, path: string) {
+  const {stripRoutePrefix} = config
+  if (!stripRoutePrefix) return path
+  if (path === "/"+stripRoutePrefix) return '/'
+  return path.replace(stripRoutePrefix.endsWith('/') ? stripRoutePrefix : stripRoutePrefix+"/", '')
+}
+
 async function writeRoutes(silent: boolean = false) {
   const config = getConfig();
   const imports: Set<string> = new Set();
@@ -59,16 +66,11 @@ async function writeRoutes(silent: boolean = false) {
   }[] = [];
   for (const { verbs, pathTemplate, importKey } of sortedPaths) {
     if (verbs.length === 0) {
-      const replacePath = (stripRoutePrefix: string | undefined) => {
-        if (!stripRoutePrefix) return pathTemplate
-        if (pathTemplate === "/"+stripRoutePrefix) return '/'
-        return pathTemplate.replace(stripRoutePrefix.endsWith('/') ? stripRoutePrefix : stripRoutePrefix+"/", '')
-      }
-      pageRoutes.push({ pathTemplate: replacePath(config.stripRoutePrefix), importKey })
+      pageRoutes.push({ pathTemplate: fixPath(config, pathTemplate), importKey })
     } else {
       for (const verb of verbs) {
         apiRoutes.push({
-          pathTemplate,
+          pathTemplate: fixPath(config, pathTemplate),
           importKey,
           verb,
           upperVerb: upperFirst(verb.toLowerCase()),

--- a/src/nextjs/build-tools.ts
+++ b/src/nextjs/build-tools.ts
@@ -59,7 +59,12 @@ async function writeRoutes(silent: boolean = false) {
   }[] = [];
   for (const { verbs, pathTemplate, importKey } of sortedPaths) {
     if (verbs.length === 0) {
-      pageRoutes.push({ pathTemplate, importKey });
+      const replacePath = (stripRoutePrefix: string | undefined) => {
+        if (!stripRoutePrefix) return pathTemplate
+        if (pathTemplate === "/"+stripRoutePrefix) return '/'
+        return pathTemplate.replace(stripRoutePrefix.endsWith('/') ? stripRoutePrefix : stripRoutePrefix+"/", '')
+      }
+      pageRoutes.push({ pathTemplate: replacePath(config.stripRoutePrefix), importKey })
     } else {
       for (const verb of verbs) {
         apiRoutes.push({


### PR DESCRIPTION
add stripRoutePrefix option to avoid react router routes to be like src/pages/route and, in general, to be able to publish routes stripping a path part

e.g.

`"/folder-name/sub-folder-name/route"` => `"/sub-folder-name/route"`