### PR TITLE
QwikCity Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Declarative Routes
 
-`declarative-routing` sets up an optional declarative routing system for React projects. For NextJS, it maintains a global list of both pages and API routes and provides components and functions to easily navigate to pages, or make API requests.
+`declarative-routing` sets up an optional declarative routing system for React or QwikCity projects. For NextJS, it maintains a global list of both pages and API routes and provides components and functions to easily navigate to pages, or make API requests.
 
 ## What are Declarative Routes?
 
@@ -13,6 +13,8 @@ With typesafe routing you still have to deal with urls; `<Link to={`/product/${p
 For NextJS projects follow the [NextJS installation instructions](./docs/nextjs.md).
 
 For React Router projects follow the [React Router installation instructions](./docs/react-router.md).
+
+For QwikCity projects follow the [QwikCiy installation instructions](./docs/qwikcity.md).
 
 # Credit where credit is due
 

--- a/assets/nextjs/README.md.template
+++ b/assets/nextjs/README.md.template
@@ -79,8 +79,8 @@ However, you may want to customize some options to change the behavior of route 
 
 You can edit `declarative-routing.config.json` in the root of your project. The following options are available:
 
-- `mode`: choose between `react-router`and `nextjs`. It is automatically picked on init based on the project type.
-- `routes`: the directory where the routes are defined. It is picked from the initial wizard (and defaults to `src/routes`).
+- `mode`: choose between `react-router`, `nextjs` or `qwikcity`. It is automatically picked on init based on the project type.
+- `routes`: the directory where the routes are defined. It is picked from the initial wizard (and defaults to `./src/components/declarativeRoutes`).
 - `importPathPrefix`: the path prefix to add to the import path of the self-generated route objects, in order to be able to resolve them. It defaults to `@/app`.
 
 # When your routes change

--- a/assets/qwikcity/README.md.template
+++ b/assets/qwikcity/README.md.template
@@ -1,0 +1,76 @@
+This application supports typesafe routing for QwikCity using the `declarative-routing` system.
+
+# What is `declarative-routing`?
+
+Declarative Routes is a system for typesafe routing in QwikCity. It uses a combination of TypeScript and a custom routing system to ensure that your routes are always in sync with your code. You'll never have to worry about broken links or missing routes again.
+
+# Route List
+
+Here are the routes of the application:
+
+| Route | Route Name | Using It |
+| ----- |  ---- | ---- |
+{{#each routes}}
+| `{{{this.pathTemplate}}}` | `{{{this.importKey}}}` | `{{{this.usage}}}` |
+{{/each}}
+
+To use the routes, you can import them from `~/components/declarativeRoutes` and use them in your code.
+
+# Using the routes in your application
+
+For pages, use the `Link` component (built on top of the `Link` component from `@builder.io/qwik-city`) to link to other pages. For example:
+
+```tsx
+import { ProductDetail } from "~/components/declarativeRoutes";
+
+return (
+  <ProductDetail.Link productId={"abc123"}>Product abc123</ProductDetail.Link>
+);
+```
+
+This is the equivalent of doing `<Link href="/product/abc123">Product abc123</Link>` but with typesafety. And you never have to remember the URL. If the route moves, the typesafe route will be updated automatically.
+
+# Configure declarative-routing
+
+After running `npx declarative-routing init`, you don't need to configure anything to use it.
+However, you may want to customize some options to change the behavior of route generation.
+
+You can edit `declarative-routing.config.json` in the root of your project. The following options are available:
+
+- `mode`: choose between `react-router`, `nextjs` or `qwikcity`. It is automatically picked on init based on the project type.
+- `routes`: the directory where to place the declarative routes. It is picked from the initial wizard (and defaults to `./src/components/declarativeRoutes`).
+- `importPathPrefix`: the path prefix to add to the import path of the self-generated route objects, in order to be able to resolve them. It defaults to `@/app`.
+
+# When your routes change
+
+You'll need to run `{{packageManager}} dr:build` to update the generated files. This will update the types and the `~/components/declarativeRoutes` module to reflect the changes.
+
+The way the system works the `routeInfo.ts` files are link to the `~/components/declarativeRoutes/index.ts` file. So changing the Zod schemas for the routes does **NOT** require a rebuild. You need to run the build command when:
+
+- You change the name of the route in the `routeInfo.ts` file
+- You change the location of the route (e.g. `/product` to `/products`)
+- You change the parameters of the route (e.g. `/product/[id]` to `/product/[productId]`)
+- You add or remove routes
+
+You can also run the build command in watch mode using `{{packageManager}} dr:build:watch` but we don't recommend using that unless you are changing routes a lot. It's a neat party trick to change a route directory name and to watch the links automagically change with hot module reloading, but routes really don't change that much.
+
+# Finishing your setup
+
+Post setup there are some additional tasks that you need to complete to completely typesafe your routes. We've compiled a handy check list so you can keep track of your progress.
+
+{{#each tasks}}
+- [ ] {{{this}}}
+{{/each}}
+Once you've got that done you can remove this section.
+
+# Why is `makeRoute` copied into the `~/components/declarativeRoutes` module?
+
+You **own** this routing system once you install it. And we anticipate as part of that ownership you'll want to customize the routing system. That's why we create a `makeRoute.tsx` file in the `~/components/declarativeRoutes` module. This file is a copy of the `makeRoute.tsx` file from the `declarative-routing` package. You can modify this file to change the behavior of the routing system.
+
+For example, you might want to change the way the `Link` component works. You can do that by modifying the `makeRoute.tsx` file.
+
+We do **NOT** recommend changing the parameters of the `makeRoute` function because that would cause incompatibility with the `build` command of `declarative-routing`.
+
+# Credit where credit is due
+
+This system is based on the work in [Fix Next.JS Routing To Have Full Type-Safety](https://www.flightcontrol.dev/blog/fix-qwikCity-routing-to-have-full-type-safety). However the original article had a significantly different interface and didn't cover API routes at all.

--- a/assets/qwikcity/makeRoute.tsx
+++ b/assets/qwikcity/makeRoute.tsx
@@ -1,0 +1,180 @@
+/*
+Derived from: https://www.flightcontrol.dev/blog/fix-nextjs-routing-to-have-full-type-safety
+*/
+import type { Component } from "@builder.io/qwik";
+import type { LinkProps } from "@builder.io/qwik-city";
+import { Link } from "@builder.io/qwik-city";
+import queryString from "query-string";
+import { z } from "zod";
+
+export type RouteInfo<
+  Params extends z.ZodSchema,
+  Search extends z.ZodSchema
+> = {
+  name: string;
+  params: Params;
+  search: Search;
+  description?: string;
+};
+
+type CoreRouteElements<
+  Params extends z.ZodSchema,
+  Search extends z.ZodSchema = typeof emptySchema
+> = {
+  params: z.output<Params>;
+  paramsSchema: Params;
+  search: z.output<Search>;
+  searchSchema: Search;
+};
+
+export type RouteBuilder<
+  Params extends z.ZodSchema,
+  Search extends z.ZodSchema
+> = CoreRouteElements<Params, Search> & {
+  (p?: z.input<Params>, search?: z.input<Search>): string;
+
+  routeName: string;
+
+  Link: Component<
+    Omit<LinkProps, "href" | "search"> &
+      z.input<Params> & {
+        search?: z.input<Search>;
+      }
+  >;
+  ParamsLink: Component<
+    Omit<LinkProps, "href" | "search"> & {
+      params?: z.input<Params>;
+      search?: z.input<Search>;
+    }
+  >;
+};
+
+function createPathBuilder<T extends Record<string, string | string[]>>(
+  route: string
+): (params: T) => string {
+  const pathArr = route.split("/");
+
+  let catchAllSegment: ((params: T) => string) | null = null;
+  if (pathArr.at(-1)?.startsWith("[[...")) {
+    const catchKey = pathArr.pop()!.replace("[[...", "").replace("]]", "");
+    catchAllSegment = (params: T) => {
+      const catchAll = params[catchKey] as unknown as string[];
+      return catchAll ? `/${catchAll.join("/")}` : "";
+    };
+  }
+
+  const elems: ((params: T) => string)[] = [];
+  for (const elem of pathArr) {
+    const catchAll = elem.match(/\[\.\.\.(.*)\]/);
+    const param = elem.match(/\[(.*)\]/);
+    if (catchAll?.[1]) {
+      const key = catchAll[1];
+      elems.push((params: T) =>
+        (params[key as unknown as string] as string[]).join("/")
+      );
+    } else if (param?.[1]) {
+      const key = param[1];
+      elems.push((params: T) => params[key as unknown as string] as string);
+    } else if (!(elem.startsWith("(") && elem.endsWith(")"))) {
+      elems.push(() => elem);
+    }
+  }
+
+  return (params: T): string => {
+    const p = elems.map((e) => e(params)).join("/");
+    if (catchAllSegment) {
+      return p + catchAllSegment(params);
+    } else {
+      return p;
+    }
+  };
+}
+
+function createRouteBuilder<
+  Params extends z.ZodSchema,
+  Search extends z.ZodSchema
+>(route: string, info: RouteInfo<Params, Search>) {
+  const fn = createPathBuilder<z.output<Params>>(route);
+
+  return (params?: z.input<Params>, search?: z.input<Search>) => {
+    let checkedParams = params || {};
+    if (info.params) {
+      const safeParams = info.params.safeParse(checkedParams);
+      if (!safeParams?.success) {
+        throw new Error(
+          `Invalid params for route ${info.name}: ${safeParams.error.message}`
+        );
+      } else {
+        checkedParams = safeParams.data;
+      }
+    }
+    const safeSearch = info.search
+      ? info.search?.safeParse(search || {})
+      : null;
+    if (info.search && !safeSearch?.success) {
+      throw new Error(
+        `Invalid search params for route ${info.name}: ${safeSearch?.error.message}`
+      );
+    }
+
+    const baseUrl = fn(checkedParams);
+    const searchString = search && queryString.stringify(search);
+    return [baseUrl, searchString ? `?${searchString}` : ""].join("");
+  };
+}
+
+const emptySchema = z.object({});
+
+export function makeRoute<
+  Params extends z.ZodSchema,
+  Search extends z.ZodSchema = typeof emptySchema
+>(
+  route: string,
+  info: RouteInfo<Params, Search>
+): RouteBuilder<Params, Search> {
+  const urlBuilder: RouteBuilder<Params, Search> = createRouteBuilder(
+    route,
+    info
+  ) as RouteBuilder<Params, Search>;
+
+  urlBuilder.routeName = info.name;
+
+  urlBuilder.ParamsLink = function RouteLink({
+    params: linkParams,
+    search: linkSearch,
+    ...props
+  }: Omit<LinkProps, "href"> & {
+    params?: z.input<Params>;
+    search?: z.input<Search>;
+  }) {
+    return <Link {...props} href={urlBuilder(linkParams, linkSearch)} />;
+  };
+
+  urlBuilder.Link = function RouteLink({
+    search: linkSearch,
+    ...props
+  }: Omit<LinkProps, "href"> &
+    z.input<Params> & {
+      search?: z.input<Search>;
+    }) {
+    const params = info.params.parse(props);
+    const extraProps = { ...props };
+    for (const key of Object.keys(params)) {
+      delete extraProps[key];
+    }
+
+    return (
+      <Link
+        {...extraProps}
+        href={urlBuilder(info.params.parse(props), linkSearch)}
+      />
+    );
+  };
+
+  urlBuilder.params = undefined as z.output<Params>;
+  urlBuilder.paramsSchema = info.params;
+  urlBuilder.search = undefined as z.output<Search>;
+  urlBuilder.searchSchema = info.search;
+
+  return urlBuilder;
+}

--- a/assets/react-router/README.md.template
+++ b/assets/react-router/README.md.template
@@ -44,7 +44,7 @@ However, you may want to customize some options to change the behavior of route 
 
 You can edit `declarative-routing.config.json` in the root of your project. The following options are available:
 
-- `mode`: choose between `react-router`and `nextjs`. It is automatically picked on init based on the project type.
+- `mode`: choose between `react-router`, `nextjs` or `qwikcity`. It is automatically picked on init based on the project type.
 - `routes`: the directory where the routes are defined. It is picked from the initial wizard (and defaults to `src/routes`).
 - `importPathPrefix`: the path prefix to add to the import path of the self-generated route objects, in order to be able to resolve them. It defaults to `@/app`.
 

--- a/docs/qwikcity.md
+++ b/docs/qwikcity.md
@@ -1,0 +1,166 @@
+## Installation and Usage on QwikCity
+
+Initialize your QwikCity application:
+
+```bash
+npx declarative-routing init
+```
+
+This will generate an `~/components/declarativeRoutes` directory that you can use to navigate to pages. It also generates a `README.md` file in the routes directory that contains information about how to use the system.
+
+You can update the files when the route paths change using the `build` command. This will update the `~/components/declarativeRoutes` directory to reflect the new paths. For example, if you add a new page, you can run the following command to update the routes:
+
+```bash
+npx declarative-routing build
+```
+
+## Using Links To Pages Routes
+
+Instead of doing this:
+
+```tsx
+import { Link } from "@builder.io/qwik-city";
+
+<Link href={`/product/${product.id}`}>Product</Link>;
+```
+
+You can do this:
+
+```tsx
+import { ProductDetail } from "~/components/declarativeRoutes";
+
+<ProductDetail.Link productId={product.id}>Product</ProductDetail.Link>;
+```
+
+## Opt-in
+
+This system is opt-in. You can use it for some routes, and not for others. You can use it for some parts of your application, and not for others. It's designed to be flexible and to work with your existing code, and to be incrementally adoptable.
+
+# How it works
+
+Routes are typed using one or more of the methods defined in `~/components/declarativeRoutes/makeRoute`.
+
+- `makeRoute` - Used for defining page routes
+
+## makeRoute
+
+`makeRoute` is used to define a page route. It takes the path of the route as a string, and an `info` object that contains the name of the route, as well as the Zod schemas for the route parameters and search parameters. Here is an example usage:
+
+```tsx
+const ProductDetail = makeRoute("/product-detail/[productId]", {
+  name: "ProductDetail",
+  params: z.object({
+    productId: z.string()
+  }),
+  search: z.object({
+    q: z.string().optional()
+  })
+});
+```
+
+The returned `ProductDetail` is a function that when invoked with the params and search parameters, returns the URL of the route. Shown below is an example usage:
+
+```tsx
+<Link href={ProductDetail({ productId: "abc123" }, { q: "foo" })}>
+  Product abc123
+</Link>
+```
+
+In addition to the function, the `ProductDetail` object also contains a `Link` component that can be used to link to the route. Shown below is an example usage:
+
+```tsx
+<ProductDetail.Link productId={"abc123"} search={{ q: "foo" }}>
+  Product abc123
+</ProductDetail.Link>
+```
+
+There is also a `ParamsLink` component that can be used to link to the route using an explicit `params` object for the params. Shown below is an example usage:
+
+```tsx
+<ProductDetail.ParamsLink
+  params={{ productId: "abc123" }}
+  search={{ q: "foo" }}
+>
+  Product abc123
+</ProductDetail.ParamsLink>
+```
+
+## The manual option
+
+You can choose to simply use the `makeRoute` functions wherever you choose to define routes.
+
+## The `build` option
+
+The automated option is to use the `build` command to generate the routes. This command will generate the routes for you based on the `index.tsx` files in your `.src/routes/` directory. For each `index.tsx` file it will generate a corresponding `routeInfo.ts` file in the same directory.
+
+It will then import those `routeInfo.ts` files into `~/components/declarativeRoutes/index.ts` so that you can import all the routes from `~/components/declarativeRoutes` and use them in your application. Inside `~/components/declarativeRoutes/index.ts` it will generate `makeRoute` invocations for each of the page routes.
+
+The /declarativeRoutes/index.ts file imports the `routeInfo.ts` files and exports routes.
+
+```mermaid
+graph TD;
+    paramRoute["/product/[productId]/routeInfo.ts"]
+    indexRoute["~/components/declarativeRoutes/index.ts"]
+    /routeInfo.ts-->indexRoute;
+    paramRoute-->indexRoute;
+    indexRoute-->Home;
+    indexRoute-->Product;
+```
+
+Components then import the `~/components/declarativeRoutes` module and use the routes to navigate to pages.
+
+```mermaid
+graph TD;
+    paramRoute["/product/[productId]/index.tsx"]
+    indexRoute["~/components/declarativeRoutes/index.ts"]
+    indexRoute-->Home;
+    indexRoute-->Product;
+    paramRoute-->Product;
+    paramRoute-.->indexRoute;
+```
+
+For example in this case the `ProductPage` component imports the `Product` page route and uses that to type its parameters.
+
+And the home page route:
+
+```mermaid
+graph TD;
+    paramRoute["/index.tsx"]
+    indexRoute["~/components/declarativeRoutes/index.ts"]
+    indexRoute-->Home;
+    indexRoute-->Product;
+    paramRoute-->Product;
+    paramRoute-.->indexRoute;
+```
+
+Just imports the `Product` route from `~/components/declarativeRoutes` and uses that to build links to the product pages.
+
+## Manually editing `routeInfo.ts` files
+
+The `routeInfo.ts` files are meant to be manually edited.
+
+For standard `routeInfo.ts` files you will need to manually edit them to add a `search` schema if the page supports search parameters.
+
+## What are `routeInfo.ts` files?
+
+The `routeInfo.ts` files are used to provide additional information about the routes. For all route types they provide the name of the route (which must be a valid Javascript variable name), the typed route parameters, and the optional route search parameters.
+
+We put the `routeInfo.ts` files in the same directory as the `index.tsx` files so that we can keep all the information about a route in one place. It's the `build` command that creates `routeInfo.ts` files if they are missing, as well as maintains the `index.ts` file in `~/components/declarativeRoutes` that has all the routes.
+
+Why not put all that information into the `index.tsx` files directly you ask?
+
+1. The `index.ts` file in the `~/components/declarativeRoutes` directory imports all the `routeInfo.ts` files from all the routes. If we imported all the `index.tsx` files directly then we would defeat any code splitting that QwikCity does. By importing the `routeInfo.ts` files, we can ensure that the flow of imports is uni-directional. The `index.ts` file imports all the `routeInfo.ts` files, and all the `index.tsx` files import the `index.ts` file. This ensures that the `index.ts` file is the root of the import tree, and that the `index.tsx` files are only imported when they are needed.
+
+## Why not copy the zod schemas into the `~/components/declarativeRoutes/index.ts` file?
+
+That would require running the `build` process continuously to keep the `~/components/declarativeRoutes/index.ts` file up to date. We want to avoid that because it would slow down the development process. We only want to run the `build` process when we know that the routes have been added, or moved.
+
+In the current model you can add search parameters, and the `~/components/declarativeRoutes/index.ts` file will not need to be updated. It will only need to be updated when the route paths change.
+
+# Why is `makeRoute` copied into the `~/components/declarativeRoutes` directory?
+
+You **own** this routing system once you install it. And we anticipate as part of that ownership you'll want to customize the routing system. That's why we create a `makeRoute.tsx` file in the `@routes` module. This file is a copy of the `makeRoute.tsx` file from the `declarative-routing` package. You can modify this file to change the behavior of the routing system.
+
+For example, you might want to change the way the `Link` component works. You can do all of that by modifying the `makeRoute.tsx` file.
+
+We do **NOT** recommend changing the parameters of the `makeRoute` function because that would cause incompatibility with the `build` command of `declarative-routing`.

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 const CONFIG = "declarative-routing.config.json";
 
 const ConfigSchema = z.object({
-  mode: z.enum(["nextjs", "react-router"]),
+  mode: z.enum(["nextjs", "react-router", "qwikcity"]),
   src: z.string().optional(),
   routes: z.string(),
   openapi: z

--- a/src/init.ts
+++ b/src/init.ts
@@ -7,6 +7,7 @@ import { type PackageJson } from "type-fest";
 import { hasConfig } from "./config";
 
 import { setupNext } from "./nextjs/init";
+import { setupQwikCity } from "./qwikcity/init";
 import { setupReactRouter } from "./react-router/init";
 
 export const init = new Command()
@@ -31,6 +32,12 @@ export const init = new Command()
     } else if (packageJson?.dependencies?.["react-router-dom"]) {
       console.log("Setting up React-Router...");
       await setupReactRouter();
+    } else if (
+      packageJson?.dependencies?.["@builder.io/qwik-city"] ||
+      packageJson.devDependencies?.["@builder.io/qwik-city"]
+    ) {
+      console.log("Setting up QwikCity...");
+      await setupQwikCity();
     } else {
       console.log(red("No supported framework detected."));
       console.log(

--- a/src/qwikcity/init.ts
+++ b/src/qwikcity/init.ts
@@ -1,0 +1,118 @@
+import path from "path";
+import fs from "fs-extra";
+import ora from "ora";
+import { red, bold, italic } from "kleur/colors";
+import logSymbols from "log-symbols";
+import prompts from "prompts";
+
+import { writeConfig } from "../config";
+
+import { getConfig } from "../config";
+import { buildFileFromTemplate } from "../template";
+import { buildFiles, buildREADME } from "../shared/build-tools";
+import {
+  getPackageManager,
+  addPackages,
+  addPackageJSONScripts
+} from "../shared/utils";
+
+const STD_PACKAGES = {
+  dependencies: ["zod", "query-string"],
+  devDependencies: []
+};
+const STD_SCRIPTS = {
+  "dr:build": "npx declarative-routing build",
+  "dr:build:watch": "npx declarative-routing build --watch"
+};
+
+export async function setup() {
+  const config = getConfig();
+
+  const { routes } = getConfig();
+
+  const spinner = ora(`Installing components...`).start();
+
+  fs.mkdirpSync(routes);
+  await buildFileFromTemplate(
+    "qwikcity/makeRoute.tsx",
+    path.resolve(routes, "./makeRoute.tsx"),
+    {}
+  );
+
+  spinner.text = "Getting package mananger.";
+
+  const pkgMgr = await getPackageManager();
+
+  spinner.text = "Installing dependencies.";
+
+  const packages = STD_PACKAGES.dependencies;
+  await addPackages(packages);
+
+  spinner.text = "Installing dev dependencies.";
+
+  const devPackages = STD_PACKAGES.devDependencies;
+  await addPackages(devPackages, true);
+
+  spinner.text = "Adding package.json scripts.";
+
+  const scripts = STD_SCRIPTS;
+  addPackageJSONScripts(scripts);
+
+  spinner.text = "Adding info files and building routes.";
+
+  const report = await buildFiles(true);
+
+  spinner.text = "Building README.";
+
+  await buildREADME(pkgMgr, config.mode);
+
+  spinner.succeed(`Done.`);
+
+  console.log(`\n${bold("Initialization completed successfully")}`);
+
+  if (report.routesAdded > 0) {
+    console.log(
+      logSymbols.success,
+      `Added ${report.routesAdded} .info files to your project.`
+    );
+  }
+  console.log(
+    logSymbols.success,
+    `Added declarative-routing support files in ${config.routes}.`
+  );
+
+  console.log(
+    `\nYour next step is to read the ${red(
+      italic(bold("README.md"))
+    )} file in the declarativeRoutes directory and follow the post setup tasks.`
+  );
+}
+
+export async function setupQwikCity() {
+  const src = "./src/routes";
+  const routes = "./src/components/declarativeRoutes";
+
+  const response = await prompts([
+    {
+      type: "text",
+      name: "src",
+      message: "What is your routes directory?",
+      initial: src
+    },
+    {
+      type: "text",
+      name: "routes",
+      message: "Where do you want the to place the declarative routes?",
+      initial: routes
+    }
+  ]);
+
+  writeConfig({
+    mode: "qwikcity",
+    src: response.src ?? src,
+    routes: response.routes ?? routes,
+    openapi: undefined
+  });
+
+  await setup();
+}

--- a/src/shared/build.ts
+++ b/src/shared/build.ts
@@ -22,19 +22,30 @@ export const build = new Command()
 
     if (opts.watch) {
       const config = getConfig();
-      chokidar
-        .watch(
-          [
+      let patterns: string[];
+      switch (config.mode) {
+        case "qwikcity":
+          patterns = [
+            "./**/routeInfo.(ts|tsx)",
+            "./**/index.(jsx|tsx)",
+            "./**/index@*.(jsx|tsx)"
+          ];
+          break;
+        default:
+          patterns = [
             "./**/(route|page).info.(ts|tsx)",
             "./**/(route|page).(js|jsx|ts|tsx)"
-          ],
-          {
-            ignored: /(^|[\/\\])\../,
-            persistent: true,
-            cwd: config.src,
-            usePolling: true
-          }
-        )
+          ];
+          break;
+      }
+
+      chokidar
+        .watch(patterns, {
+          ignored: /(^|[\/\\])\../,
+          persistent: true,
+          cwd: config.src,
+          usePolling: true
+        })
         .on("ready", () => {
           finishedProcessing();
         })

--- a/src/shared/watch.ts
+++ b/src/shared/watch.ts
@@ -1,3 +1,4 @@
+import { getConfig } from "../config";
 import {
   updateBuildFiles,
   parseInfoFile,
@@ -26,9 +27,34 @@ const checkForFinishedProcessing = async () => {
   }
 };
 
-const isInfoFile = (path: string) => path.match(/\.info\.ts(x?)$/);
-const isRouteFile = (path: string) =>
-  path.match(/(page|route)\.(js|jsx|ts|tsx)$/);
+const isInfoFile = (path: string) => {
+  const config = getConfig();
+  let matcher: RegExp;
+  switch (config.mode) {
+    case "qwikcity":
+      matcher = /routeInfo\.ts$/;
+      break;
+    default:
+      matcher = /\.info\.ts(x?)$/;
+      break;
+  }
+
+  return path.match(matcher);
+};
+const isRouteFile = (path: string) => {
+  const config = getConfig();
+  let matcher: RegExp;
+  switch (config.mode) {
+    case "qwikcity":
+      matcher = /index\.(js|jsx|ts|tsx)$/;
+      break;
+
+    default:
+      matcher = /(page|route)\.(js|jsx|ts|tsx)$/;
+      break;
+  }
+  return path.match(matcher);
+};
 
 export const processFile = (path: string) => {
   if (realTime) {


### PR DESCRIPTION
# Qwik City

This PR adds the ability to use the `declarative route` system in QwikCity applications. 

`QwikCity` does routing a little differently. They have `index` files as the routes so instead of using `index.info.ts` files I decided on `routeInfo.ts` files to avoid conflicts. 

This PR supports regular routes, as well as routes using [named layouts](https://qwik.dev/docs/advanced/routing/#named-layout) and [grouped layouts](https://qwik.dev/docs/advanced/routing/#grouped-layouts). 

For this first iteration I left out any `API routes` and `OpenAI`.

There are a few areas where I needed to add/change some shared items, so I have used a `switch` statement, with a `case` for `qwikcity` with my new config options, and the default being the prior code. This should help if any additional configs get added later, they can just add the `case` for w/e new config is added

This is in regards to Issue #11 
