### PR TITLE
Resolves ProNextJS/declarative-routing#30

### DIFF
--- a/assets/shared/index.ts.template
+++ b/assets/shared/index.ts.template
@@ -27,6 +27,6 @@ export const {{{this.lowerVerb}}}{{{this.importKey}}} = make{{{this.upperVerb}}}
     ...defaultInfo,
     ...{{{this.importKey}}}Route.Route
   },
-  {{{this.importKey}}}Route.{{{this.verb}}}
+  {{#if isNotDELETE}}{{{this.importKey}}}Route.{{{this.verb}}}{{/if}}
 );
 {{/each}}

--- a/src/shared/build-tools.ts
+++ b/src/shared/build-tools.ts
@@ -68,6 +68,7 @@ async function writeRoutes(silent: boolean = false) {
     verb: string;
     upperVerb: string;
     lowerVerb: string;
+    isNotDELETE: boolean
   }[] = [];
   for (const { verbs, pathTemplate, importKey } of sortedPaths) {
     if (verbs.length === 0) {
@@ -82,7 +83,8 @@ async function writeRoutes(silent: boolean = false) {
           importKey,
           verb,
           upperVerb: upperFirst(verb.toLowerCase()),
-          lowerVerb: verb.toLowerCase()
+          lowerVerb: verb.toLowerCase(),
+          isNotDELETE: verb !== "DELETE",
         });
       }
     }


### PR DESCRIPTION
Do not include zod schemas when generating DELETE routes.

It may be worth eventually including schemas to DELETE routes since results and bodies are possible with DELETE requests, but this will get DELETE routes working this the routes generator.