### PR TITLE
Add regex for openapi paths

### DIFF
--- a/src/shared/build-tools.ts
+++ b/src/shared/build-tools.ts
@@ -348,7 +348,7 @@ async function writeOpenAPI(config: Config) {
         registrations.push(
           await buildStringFromTemplate("shared/openapi-register.template", {
             lowerVerb: verb.toLowerCase(),
-            pathTemplate: path.pathTemplate,
+            pathTemplate: path.pathTemplate.replace(/\[(.*)\]/g, '{$1}'),
             verb,
             importKey: path.importKey,
             isNotDELETE: verb !== "DELETE",


### PR DESCRIPTION
The Openapi spec uses braces for its parameters and not brackets. If the path has brackets, replace them with braces so applications that use the openapi spec can replace the parameters in the path.