### PR TITLE
Safe parse search params

### DIFF
--- a/assets/shared/utils.ts
+++ b/assets/shared/utils.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+
+export function safeParseSearchParams<T extends z.AnyZodObject>(schema: T, searchParams: URLSearchParams): Partial<z.infer<T>> {
+    type ParsedData<T> = { error: string; data?: undefined; } | { data: T; error?: undefined }
+    type ParsedArrayData<T> = { error: string; data?: undefined; } | { data: T[]; error?: undefined }
+    
+    const paramsArray = getSearchParamsAsArrayRecord(searchParams)
+
+    const shape = schema.shape;
+    const parsed: Record<string, any> = {};
+
+    for (const key in shape) {
+        if (shape.hasOwnProperty(key)) {
+            const fieldSchema: z.ZodTypeAny = shape[key];
+            if (paramsArray[key]) {
+                const fieldData = convertToRequiredType(paramsArray[key], fieldSchema)
+
+                if (fieldData.error) {
+                    console.info(key, fieldData.error)
+                    continue;
+                }
+
+                const result = fieldSchema.safeParse(fieldData.data!);
+                if (result.success) parsed[key] = result.data;
+            }
+        }
+    }
+    return parsed;
+
+    function getSearchParamsAsArrayRecord(searchParams: URLSearchParams): Record<string, string[]> {
+        const params: Record<string, string[]> = {};
+
+        searchParams.forEach((value, key) => {
+            if (!params[key]) {
+                params[key] = [];
+            }
+            params[key].push(value);
+        });
+
+        return params;
+    }
+    
+    function convertToRequiredType(values: string[], schema: z.ZodTypeAny): ParsedArrayData<any> | ParsedData<any> {
+        if (schema instanceof z.ZodOptional) {
+            schema = schema._def.innerType
+        }
+        if (values.length > 1 && !(schema instanceof z.ZodArray))
+            return { error: "Multiple values for non-array field" }
+
+        switch (schema.constructor) {
+            case z.ZodNumber: return parseNumber(values[0])
+            case z.ZodBoolean: return parseBoolean(values[0])
+            case z.ZodString: return { data: values[0] }
+            case z.ZodArray: {
+                const elementSchema = schema._def.type;
+                switch (elementSchema.constructor) {
+                    case z.ZodNumber: return parseArray(values, parseNumber)
+                    case z.ZodBoolean: return parseArray(values, parseBoolean)
+                    case z.ZodString: return { data: values };
+                    default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
+                }
+            }
+            default: return { error: "unsupported type " + String(schema.constructor) }
+        }
+    }
+
+    function parseNumber(str: string): ParsedData<number> {
+        const num = +str
+        return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
+    }
+
+    function parseBoolean(str: string): ParsedData<boolean> {
+        switch (str) {
+            case "true": return { data: true };
+            case "false": return { data: false };
+            default: return { error: `${str} is not a boolean` };
+        }
+    }
+
+
+
+    function parseArray<T>(values: string[], parseFunction: (str: string) => ParsedData<T>): ParsedArrayData<T> {
+        const numbers = values.map(parseFunction)
+        const error = numbers.find(n => n.error)?.error
+        if (error) return { error }
+        return { data: numbers.map(n => n.data!) }
+    }
+
+}
+

--- a/assets/shared/utils.ts
+++ b/assets/shared/utils.ts
@@ -1,12 +1,53 @@
 import { z } from "zod";
 
-export function safeParseSearchParams<T extends z.AnyZodObject>(schema: T, searchParams: URLSearchParams): Partial<z.infer<T>> {
-    type ParsedData<T> = { error: string; data?: undefined; } | { data: T; error?: undefined }
-    type ParsedArrayData<T> = { error: string; data?: undefined; } | { data: T[]; error?: undefined }
-    
-    const paramsArray = getSearchParamsAsArrayRecord(searchParams)
+type ParsedData<T> = { error?: string; data?: T; }
 
-    const shape = schema.shape;
+export function safeParseSearchParams<T extends z.ZodTypeAny>(schema: T, searchParams: URLSearchParams): z.infer<T> {
+    const paramsArray = getAllParamsAsArrays(searchParams)
+    return processSchema(schema, paramsArray);
+}
+
+function processSchema(schema: z.ZodTypeAny, paramsArray: Record<string, string[]>): Record<string, any> {
+    if (schema instanceof z.ZodOptional) {
+        schema = schema._def.innerType
+    }
+    switch (schema.constructor) {
+        case z.ZodObject: {
+            const shape = (schema as z.ZodObject<z.ZodRawShape>).shape;
+            return parseShape(shape, paramsArray);
+        }
+        case z.ZodUnion: {
+            const options = (schema as z.ZodUnion<[z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]>)._def.options;
+            for (const option of options) {
+                const shape = option.shape;
+                const requireds = getRequireds(shape)
+
+                const result = parseShape(shape, paramsArray, true);
+                const keys = Object.keys(result);
+
+                if (requireds.every(key => keys.includes(key))) {
+                    return result;
+                }
+            }
+            return {}
+        }
+        default:
+            throw new Error("Unsupported schema type");
+    }
+}
+
+function getRequireds(shape: z.ZodRawShape) {
+    const keys: string[] = []
+    for (const key in shape) {
+        const fieldShape = shape[key];
+        if (!(fieldShape instanceof z.ZodDefault)
+            && !(fieldShape instanceof z.ZodOptional))
+            keys.push(key)
+    }
+    return keys;
+}
+
+function parseShape(shape: z.ZodRawShape, paramsArray: Record<string, string[]>, isPartOfUnion = false): Record<string, any> {
     const parsed: Record<string, any> = {};
 
     for (const key in shape) {
@@ -16,75 +57,92 @@ export function safeParseSearchParams<T extends z.AnyZodObject>(schema: T, searc
                 const fieldData = convertToRequiredType(paramsArray[key], fieldSchema)
 
                 if (fieldData.error) {
-                    console.info(key, fieldData.error)
+                    if (isPartOfUnion)
+                        return {}
                     continue;
                 }
-
                 const result = fieldSchema.safeParse(fieldData.data!);
                 if (result.success) parsed[key] = result.data;
             }
-        }
-    }
-    return parsed;
+            else if (fieldSchema instanceof z.ZodDefault) {
+                const result = fieldSchema.safeParse(undefined);
+                if (result.success) parsed[key] = result.data;
 
-    function getSearchParamsAsArrayRecord(searchParams: URLSearchParams): Record<string, string[]> {
-        const params: Record<string, string[]> = {};
-
-        searchParams.forEach((value, key) => {
-            if (!params[key]) {
-                params[key] = [];
             }
-            params[key].push(value);
-        });
-
-        return params;
-    }
-    
-    function convertToRequiredType(values: string[], schema: z.ZodTypeAny): ParsedArrayData<any> | ParsedData<any> {
-        if (schema instanceof z.ZodOptional) {
-            schema = schema._def.innerType
-        }
-        if (values.length > 1 && !(schema instanceof z.ZodArray))
-            return { error: "Multiple values for non-array field" }
-
-        switch (schema.constructor) {
-            case z.ZodNumber: return parseNumber(values[0])
-            case z.ZodBoolean: return parseBoolean(values[0])
-            case z.ZodString: return { data: values[0] }
-            case z.ZodArray: {
-                const elementSchema = schema._def.type;
-                switch (elementSchema.constructor) {
-                    case z.ZodNumber: return parseArray(values, parseNumber)
-                    case z.ZodBoolean: return parseArray(values, parseBoolean)
-                    case z.ZodString: return { data: values };
-                    default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
-                }
-            }
-            default: return { error: "unsupported type " + String(schema.constructor) }
         }
     }
 
-    function parseNumber(str: string): ParsedData<number> {
-        const num = +str
-        return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
-    }
-
-    function parseBoolean(str: string): ParsedData<boolean> {
-        switch (str) {
-            case "true": return { data: true };
-            case "false": return { data: false };
-            default: return { error: `${str} is not a boolean` };
-        }
-    }
-
-
-
-    function parseArray<T>(values: string[], parseFunction: (str: string) => ParsedData<T>): ParsedArrayData<T> {
-        const numbers = values.map(parseFunction)
-        const error = numbers.find(n => n.error)?.error
-        if (error) return { error }
-        return { data: numbers.map(n => n.data!) }
-    }
-
+    return parsed
 }
 
+function getAllParamsAsArrays(searchParams: URLSearchParams): Record<string, string[]> {
+    const params: Record<string, string[]> = {};
+
+    searchParams.forEach((value, key) => {
+        if (!params[key]) {
+            params[key] = [];
+        }
+        params[key].push(value);
+    });
+
+    return params;
+}
+
+function convertToRequiredType(values: string[], schema: z.ZodTypeAny): ParsedData<any> {
+    const usedSchema = getInnerType(schema)
+    if (values.length > 1 && !(usedSchema instanceof z.ZodArray))
+        return { error: "Multiple values for non-array field" }
+    const value = parseValues(usedSchema, values)
+    if (value.error && schema.constructor === z.ZodDefault) {
+        return { data: undefined }
+    }
+    return value;
+}
+
+function parseValues(schema: any, values: string[]): ParsedData<any> {
+    switch (schema.constructor) {
+        case z.ZodNumber: return parseNumber(values[0])
+        case z.ZodBoolean: return parseBoolean(values[0])
+        case z.ZodString: return { data: values[0] }
+        case z.ZodArray: {
+            const elementSchema = schema._def.type;
+            switch (elementSchema.constructor) {
+                case z.ZodNumber: return parseArray(values, parseNumber)
+                case z.ZodBoolean: return parseArray(values, parseBoolean)
+                case z.ZodString: return { data: values };
+                default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
+            }
+        }
+        default: return { error: "unsupported type " + String(schema.constructor) }
+    }
+}
+
+function getInnerType(schema: z.ZodTypeAny) {
+    switch (schema.constructor) {
+        case z.ZodOptional:
+        case z.ZodDefault:
+            return schema._def.innerType
+        default:
+            return schema;
+    }
+}
+
+function parseNumber(str: string): ParsedData<number> {
+    const num = +str
+    return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
+}
+
+function parseBoolean(str: string): ParsedData<boolean> {
+    switch (str) {
+        case "true": return { data: true };
+        case "false": return { data: false };
+        default: return { error: `${str} is not a boolean` };
+    }
+}
+
+function parseArray<T>(values: string[], parseFunction: (str: string) => ParsedData<T>): ParsedData<T[]> {
+    const numbers = values.map(parseFunction)
+    const error = numbers.find(n => n.error)?.error
+    if (error) return { error }
+    return { data: numbers.map(n => n.data!) }
+}

--- a/examples/nextjs/finished/src/app/api/pokemon/route.info.ts
+++ b/examples/nextjs/finished/src/app/api/pokemon/route.info.ts
@@ -6,8 +6,8 @@ export const Route = {
   name: "PokemonSearch",
   params: z.object({}),
   search: z.object({
-    q: z.string().optional(),
-    limit: z.coerce.number().optional()
+    q: z.string().default(""),
+    limit: z.number().default(10)
   })
 };
 

--- a/examples/nextjs/finished/src/app/api/pokemon/route.ts
+++ b/examples/nextjs/finished/src/app/api/pokemon/route.ts
@@ -6,9 +6,6 @@ import { getFullPokemon } from "@/pokemon";
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
-  const searchParams = safeParseSearchParams(Route.search, req.nextUrl.searchParams)
-  const q = searchParams.q ?? "";
-  const limit = searchParams.limit ?? 10;
-  return NextResponse.json(await getFullPokemon(+limit, q));
+  const { q, limit } = safeParseSearchParams(Route.search, req.nextUrl.searchParams)
+  return NextResponse.json(await getFullPokemon(limit, q));
 }

--- a/examples/nextjs/finished/src/app/api/pokemon/route.ts
+++ b/examples/nextjs/finished/src/app/api/pokemon/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { safeParseSearchParams } from "routes/utils"
+import { safeParseSearchParams } from "@/routes/utils"
 import { Route } from "./route.info"
 import { getFullPokemon } from "@/pokemon";
 
@@ -8,7 +8,7 @@ export const dynamic = "force-dynamic";
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const searchParams = safeParseSearchParams(Route.search, req.nextUrl.searchParams)
-  const q = url.searchParams.get("q") ?? "";
-  const limit = url.searchParams.get("limit") ?? 10;
+  const q = searchParams.q ?? "";
+  const limit = searchParams.limit ?? 10;
   return NextResponse.json(await getFullPokemon(+limit, q));
 }

--- a/examples/nextjs/finished/src/app/api/pokemon/route.ts
+++ b/examples/nextjs/finished/src/app/api/pokemon/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-
+import { safeParseSearchParams } from "routes/utils"
+import { Route } from "./route.info"
 import { getFullPokemon } from "@/pokemon";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
+  const searchParams = safeParseSearchParams(Route.search, req.nextUrl.searchParams)
   const q = url.searchParams.get("q") ?? "";
   const limit = url.searchParams.get("limit") ?? 10;
   return NextResponse.json(await getFullPokemon(+limit, q));

--- a/examples/nextjs/finished/src/routes/utils.ts
+++ b/examples/nextjs/finished/src/routes/utils.ts
@@ -1,12 +1,6 @@
 import { z } from "zod";
-import qs from "query-string"
 
-export function safeParseSearchParams<T extends z.ZodTypeAny>(schema: T, query: string): z.infer<T> {
-    const data = qs.parse(query, { parseNumbers: true, parseBooleans: true })
-    return schema.safeParse(data)
-}
-
-export function customSafeParseSearchParams<T extends z.ZodTypeAny>(schema: T, searchParams: URLSearchParams): z.infer<T> {
+export function safeParseSearchParams<T extends z.ZodTypeAny>(schema: T, searchParams: URLSearchParams): z.infer<T> {
 
     const paramsArray = getAllParamsAsArrays(searchParams)
     return processSchema(schema, paramsArray);
@@ -120,4 +114,3 @@ export function customSafeParseSearchParams<T extends z.ZodTypeAny>(schema: T, s
     type ParsedArrayData<T> = { error: string; data?: undefined; } | { data: T[]; error?: undefined }
 
 }
-

--- a/examples/nextjs/finished/src/routes/utils.ts
+++ b/examples/nextjs/finished/src/routes/utils.ts
@@ -1,0 +1,124 @@
+import { z } from "zod";
+import qs from "query-string"
+
+export function safeParseSearchParams<T extends z.ZodTypeAny>(schema: T, query: string): z.infer<T> {
+    const data = qs.parse(query)
+    return schema.safeParse(data)
+}
+
+export function customSafeParseSearchParams<T extends z.ZodTypeAny>(schema: T, searchParams: URLSearchParams): z.infer<T> {
+
+    const paramsArray = getAllParamsAsArrays(searchParams)
+    return processSchema(schema, paramsArray);
+  
+    function processSchema(schema: z.ZodTypeAny, paramsArray: Record<string, string[]>): Record<string, any> {
+      if (schema instanceof z.ZodOptional) {
+        schema = schema._def.innerType
+      }
+      switch (schema.constructor) {
+        case z.ZodObject: {
+          const shape = (schema as z.ZodObject<z.ZodRawShape>).shape;
+          return parseShape(shape, paramsArray);
+        }
+        case z.ZodUnion: {
+          const options = (schema as z.ZodUnion<[z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]>)._def.options;
+          for (const option of options) {
+            const result = parseShape(option.shape, paramsArray, true);
+            if (result && Object.keys(result).length > 0) {
+              return result;
+            }
+          }
+          return {}
+        }
+        default:
+          throw new Error("Unsupported schema type");
+      }
+    }
+  
+    function parseShape(shape: z.ZodRawShape, paramsArray: Record<string, string[]>, isPartOfUnion = false): Record<string, any> {
+      const parsed: Record<string, any> = {};
+  
+      for (const key in shape) {
+        if (shape.hasOwnProperty(key)) {
+          const fieldSchema: z.ZodTypeAny = shape[key];
+          if (paramsArray[key]) {
+            const fieldData = convertToRequiredType(paramsArray[key], fieldSchema)
+  
+            if (fieldData.error) {
+              if (isPartOfUnion)
+                return {}
+              continue;
+            }
+              const result = fieldSchema.safeParse(fieldData.data!);
+              if (result.success) parsed[key] = result.data;
+          }
+        }
+      }
+      return parsed;
+    }
+  
+  
+    function getAllParamsAsArrays(searchParams: URLSearchParams): Record<string, string[]> {
+      const params: Record<string, string[]> = {};
+  
+      searchParams.forEach((value, key) => {
+        if (!params[key]) {
+          params[key] = [];
+        }
+        params[key].push(value);
+      });
+  
+      return params;
+    }
+  
+    function convertToRequiredType(values: string[], schema: z.ZodTypeAny): ParsedArrayData<any> | ParsedData<any> {
+      if (schema instanceof z.ZodOptional) {
+        schema = schema._def.innerType
+      }
+      if (values.length > 1 && !(schema instanceof z.ZodArray))
+        return { error: "Multiple values for non-array field" }
+  
+      switch (schema.constructor) {
+        case z.ZodNumber: return parseNumber(values[0])
+        case z.ZodBoolean: return parseBoolean(values[0])
+        case z.ZodString: return { data: values[0] }
+        case z.ZodArray: {
+          const elementSchema = schema._def.type;
+          switch (elementSchema.constructor) {
+            case z.ZodNumber: return parseArray(values, parseNumber)
+            case z.ZodBoolean: return parseArray(values, parseBoolean)
+            case z.ZodString: return { data: values };
+            default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
+          }
+        }
+        default: return { error: "unsupported type " + String(schema.constructor) }
+      }
+    }
+  
+    function parseNumber(str: string): ParsedData<number> {
+      const num = +str
+      return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
+    }
+  
+    function parseBoolean(str: string): ParsedData<boolean> {
+      switch (str) {
+        case "true": return { data: true };
+        case "false": return { data: false };
+        default: return { error: `${str} is not a boolean` };
+      }
+    }
+  
+  
+    function parseArray<T>(values: string[], parseFunction: (str: string) => ParsedData<T>): ParsedArrayData<T> {
+      const numbers = values.map(parseFunction)
+      const error = numbers.find(n => n.error)?.error
+      if (error) return { error }
+      return { data: numbers.map(n => n.data!) }
+    }
+  
+    type ParsedData<T> = { error: string; data?: undefined; } | { data: T; error?: undefined }
+    type ParsedArrayData<T> = { error: string; data?: undefined; } | { data: T[]; error?: undefined }
+  
+  }
+  
+  

--- a/examples/nextjs/finished/src/routes/utils.ts
+++ b/examples/nextjs/finished/src/routes/utils.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import qs from "query-string"
 
 export function safeParseSearchParams<T extends z.ZodTypeAny>(schema: T, query: string): z.infer<T> {
-    const data = qs.parse(query)
+    const data = qs.parse(query, { parseNumbers: true, parseBooleans: true })
     return schema.safeParse(data)
 }
 
@@ -10,115 +10,114 @@ export function customSafeParseSearchParams<T extends z.ZodTypeAny>(schema: T, s
 
     const paramsArray = getAllParamsAsArrays(searchParams)
     return processSchema(schema, paramsArray);
-  
+
     function processSchema(schema: z.ZodTypeAny, paramsArray: Record<string, string[]>): Record<string, any> {
-      if (schema instanceof z.ZodOptional) {
-        schema = schema._def.innerType
-      }
-      switch (schema.constructor) {
-        case z.ZodObject: {
-          const shape = (schema as z.ZodObject<z.ZodRawShape>).shape;
-          return parseShape(shape, paramsArray);
+        if (schema instanceof z.ZodOptional) {
+            schema = schema._def.innerType
         }
-        case z.ZodUnion: {
-          const options = (schema as z.ZodUnion<[z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]>)._def.options;
-          for (const option of options) {
-            const result = parseShape(option.shape, paramsArray, true);
-            if (result && Object.keys(result).length > 0) {
-              return result;
+        switch (schema.constructor) {
+            case z.ZodObject: {
+                const shape = (schema as z.ZodObject<z.ZodRawShape>).shape;
+                return parseShape(shape, paramsArray);
             }
-          }
-          return {}
-        }
-        default:
-          throw new Error("Unsupported schema type");
-      }
-    }
-  
-    function parseShape(shape: z.ZodRawShape, paramsArray: Record<string, string[]>, isPartOfUnion = false): Record<string, any> {
-      const parsed: Record<string, any> = {};
-  
-      for (const key in shape) {
-        if (shape.hasOwnProperty(key)) {
-          const fieldSchema: z.ZodTypeAny = shape[key];
-          if (paramsArray[key]) {
-            const fieldData = convertToRequiredType(paramsArray[key], fieldSchema)
-  
-            if (fieldData.error) {
-              if (isPartOfUnion)
+            case z.ZodUnion: {
+                const options = (schema as z.ZodUnion<[z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]>)._def.options;
+                for (const option of options) {
+                    const result = parseShape(option.shape, paramsArray, true);
+                    if (result && Object.keys(result).length > 0) {
+                        return result;
+                    }
+                }
                 return {}
-              continue;
             }
-              const result = fieldSchema.safeParse(fieldData.data!);
-              if (result.success) parsed[key] = result.data;
-          }
+            default:
+                throw new Error("Unsupported schema type");
         }
-      }
-      return parsed;
     }
-  
-  
+
+    function parseShape(shape: z.ZodRawShape, paramsArray: Record<string, string[]>, isPartOfUnion = false): Record<string, any> {
+        const parsed: Record<string, any> = {};
+
+        for (const key in shape) {
+            if (shape.hasOwnProperty(key)) {
+                const fieldSchema: z.ZodTypeAny = shape[key];
+                if (paramsArray[key]) {
+                    const fieldData = convertToRequiredType(paramsArray[key], fieldSchema)
+
+                    if (fieldData.error) {
+                        if (isPartOfUnion)
+                            return {}
+                        continue;
+                    }
+                    const result = fieldSchema.safeParse(fieldData.data!);
+                    if (result.success) parsed[key] = result.data;
+                }
+            }
+        }
+        return parsed;
+    }
+
+
     function getAllParamsAsArrays(searchParams: URLSearchParams): Record<string, string[]> {
-      const params: Record<string, string[]> = {};
-  
-      searchParams.forEach((value, key) => {
-        if (!params[key]) {
-          params[key] = [];
-        }
-        params[key].push(value);
-      });
-  
-      return params;
+        const params: Record<string, string[]> = {};
+
+        searchParams.forEach((value, key) => {
+            if (!params[key]) {
+                params[key] = [];
+            }
+            params[key].push(value);
+        });
+
+        return params;
     }
-  
+
     function convertToRequiredType(values: string[], schema: z.ZodTypeAny): ParsedArrayData<any> | ParsedData<any> {
-      if (schema instanceof z.ZodOptional) {
-        schema = schema._def.innerType
-      }
-      if (values.length > 1 && !(schema instanceof z.ZodArray))
-        return { error: "Multiple values for non-array field" }
-  
-      switch (schema.constructor) {
-        case z.ZodNumber: return parseNumber(values[0])
-        case z.ZodBoolean: return parseBoolean(values[0])
-        case z.ZodString: return { data: values[0] }
-        case z.ZodArray: {
-          const elementSchema = schema._def.type;
-          switch (elementSchema.constructor) {
-            case z.ZodNumber: return parseArray(values, parseNumber)
-            case z.ZodBoolean: return parseArray(values, parseBoolean)
-            case z.ZodString: return { data: values };
-            default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
-          }
+        if (schema instanceof z.ZodOptional) {
+            schema = schema._def.innerType
         }
-        default: return { error: "unsupported type " + String(schema.constructor) }
-      }
+        if (values.length > 1 && !(schema instanceof z.ZodArray))
+            return { error: "Multiple values for non-array field" }
+
+        switch (schema.constructor) {
+            case z.ZodNumber: return parseNumber(values[0])
+            case z.ZodBoolean: return parseBoolean(values[0])
+            case z.ZodString: return { data: values[0] }
+            case z.ZodArray: {
+                const elementSchema = schema._def.type;
+                switch (elementSchema.constructor) {
+                    case z.ZodNumber: return parseArray(values, parseNumber)
+                    case z.ZodBoolean: return parseArray(values, parseBoolean)
+                    case z.ZodString: return { data: values };
+                    default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
+                }
+            }
+            default: return { error: "unsupported type " + String(schema.constructor) }
+        }
     }
-  
+
     function parseNumber(str: string): ParsedData<number> {
-      const num = +str
-      return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
+        const num = +str
+        return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
     }
-  
+
     function parseBoolean(str: string): ParsedData<boolean> {
-      switch (str) {
-        case "true": return { data: true };
-        case "false": return { data: false };
-        default: return { error: `${str} is not a boolean` };
-      }
+        switch (str) {
+            case "true": return { data: true };
+            case "false": return { data: false };
+            default: return { error: `${str} is not a boolean` };
+        }
     }
-  
-  
+
+
     function parseArray<T>(values: string[], parseFunction: (str: string) => ParsedData<T>): ParsedArrayData<T> {
-      const numbers = values.map(parseFunction)
-      const error = numbers.find(n => n.error)?.error
-      if (error) return { error }
-      return { data: numbers.map(n => n.data!) }
+        const numbers = values.map(parseFunction)
+        const error = numbers.find(n => n.error)?.error
+        if (error) return { error }
+        return { data: numbers.map(n => n.data!) }
     }
-  
+
     type ParsedData<T> = { error: string; data?: undefined; } | { data: T; error?: undefined }
     type ParsedArrayData<T> = { error: string; data?: undefined; } | { data: T[]; error?: undefined }
-  
-  }
-  
-  
+
+}
+

--- a/examples/nextjs/finished/src/routes/utils.ts
+++ b/examples/nextjs/finished/src/routes/utils.ts
@@ -1,156 +1,148 @@
 import { z } from "zod";
 
-export function safeParseSearchParams<T extends z.ZodTypeAny>(schema: T, searchParams: URLSearchParams): z.infer<T> {
+type ParsedData<T> = { error?: string; data?: T; }
 
+export function safeParseSearchParams<T extends z.ZodTypeAny>(schema: T, searchParams: URLSearchParams): z.infer<T> {
     const paramsArray = getAllParamsAsArrays(searchParams)
     return processSchema(schema, paramsArray);
-
-    function processSchema(schema: z.ZodTypeAny, paramsArray: Record<string, string[]>): Record<string, any> {
-        if (schema instanceof z.ZodOptional) {
-            schema = schema._def.innerType
-        }
-        switch (schema.constructor) {
-            case z.ZodObject: {
-                const shape = (schema as z.ZodObject<z.ZodRawShape>).shape;
-                return parseShape(shape, paramsArray);
-            }
-            case z.ZodUnion: {
-                const options = (schema as z.ZodUnion<[z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]>)._def.options;
-                for (const option of options) {
-                    const shape = option.shape;
-                    const requireds = getRequireds(shape)
-
-                    const result = parseShape(shape, paramsArray, true);
-                    const keys = Object.keys(result);
-
-                    if (requireds.every(key => keys.includes(key))) {
-                        return result;
-                    }
-                }
-                return {}
-            }
-            default:
-                throw new Error("Unsupported schema type");
-        }
-    }
-
-    function getRequireds(shape: z.ZodRawShape) {
-        const keys = []
-        for (const key in shape) {
-            const fieldShape = shape[key];
-            if (!(fieldShape instanceof z.ZodDefault)
-                && !(fieldShape instanceof z.ZodOptional))
-                keys.push(key)
-        }
-        return keys;
-    }
-
-    function parseShape(shape: z.ZodRawShape, paramsArray: Record<string, string[]>, isPartOfUnion = false): Record<string, any> {
-        const parsed: Record<string, any> = {};
-
-        for (const key in shape) {
-            if (shape.hasOwnProperty(key)) {
-                const fieldSchema: z.ZodTypeAny = shape[key];
-                if (paramsArray[key]) {
-                    const fieldData = convertToRequiredType(paramsArray[key], fieldSchema)
-
-                    if (fieldData.error) {
-                        if (isPartOfUnion)
-                            return {}
-                        continue;
-                    }
-                    const result = fieldSchema.safeParse(fieldData.data!);
-                    if (result.success) parsed[key] = result.data;
-                }
-                else if (fieldSchema instanceof z.ZodDefault) {
-                    const result = fieldSchema.safeParse(undefined);
-                    if (result.success) parsed[key] = result.data;
-
-                }
-            }
-        }
-
-        return parsed
-    }
-
-
-    function getAllParamsAsArrays(searchParams: URLSearchParams): Record<string, string[]> {
-        const params: Record<string, string[]> = {};
-
-        searchParams.forEach((value, key) => {
-            if (!params[key]) {
-                params[key] = [];
-            }
-            params[key].push(value);
-        });
-
-        return params;
-    }
-
-    function convertToRequiredType(values: string[], schema: z.ZodTypeAny): ParsedData<any> {
-        const usedSchema = getInnerType(schema)
-        if (values.length > 1 && !(usedSchema instanceof z.ZodArray))
-            return { error: "Multiple values for non-array field" }
-        const value = parseValues(usedSchema, values)
-        if (value.error && schema.constructor === z.ZodDefault) {
-            return { data: undefined }
-        }
-        return value;
-    }
-
-    function parseValues(schema: any, values: string[]): ParsedData<any> {
-        switch (schema.constructor) {
-            case z.ZodNumber: return parseNumber(values[0])
-            case z.ZodBoolean: return parseBoolean(values[0])
-            case z.ZodString: return { data: values[0] }
-            case z.ZodArray: {
-                const elementSchema = schema._def.type;
-                switch (elementSchema.constructor) {
-                    case z.ZodNumber: return parseArray(values, parseNumber)
-                    case z.ZodBoolean: return parseArray(values, parseBoolean)
-                    case z.ZodString: return { data: values };
-                    default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
-                }
-            }
-            default: return { error: "unsupported type " + String(schema.constructor) }
-        }
-    }
-
-    function getInnerType(schema: z.ZodTypeAny) {
-        switch (schema.constructor) {
-            case z.ZodOptional:
-            case z.ZodDefault:
-                return schema._def.innerType
-            default:
-                return schema;
-        }
-    }
-
-    function parseNumber(str: string): ParsedData<number> {
-        const num = +str
-        return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
-    }
-
-    function parseBoolean(str: string): ParsedData<boolean> {
-        switch (str) {
-            case "true": return { data: true };
-            case "false": return { data: false };
-            default: return { error: `${str} is not a boolean` };
-        }
-    }
-
-
-    function parseArray<T>(values: string[], parseFunction: (str: string) => ParsedData<T>): ParsedData<T[]> {
-        const numbers = values.map(parseFunction)
-        const error = numbers.find(n => n.error)?.error
-        if (error) return { error }
-        return { data: numbers.map(n => n.data!) }
-    }
-
-    type ParsedData<T> = { error?: string; data?: T; }
-
 }
 
+function processSchema(schema: z.ZodTypeAny, paramsArray: Record<string, string[]>): Record<string, any> {
+    if (schema instanceof z.ZodOptional) {
+        schema = schema._def.innerType
+    }
+    switch (schema.constructor) {
+        case z.ZodObject: {
+            const shape = (schema as z.ZodObject<z.ZodRawShape>).shape;
+            return parseShape(shape, paramsArray);
+        }
+        case z.ZodUnion: {
+            const options = (schema as z.ZodUnion<[z.ZodObject<z.ZodRawShape>, ...z.ZodObject<z.ZodRawShape>[]]>)._def.options;
+            for (const option of options) {
+                const shape = option.shape;
+                const requireds = getRequireds(shape)
 
+                const result = parseShape(shape, paramsArray, true);
+                const keys = Object.keys(result);
 
+                if (requireds.every(key => keys.includes(key))) {
+                    return result;
+                }
+            }
+            return {}
+        }
+        default:
+            throw new Error("Unsupported schema type");
+    }
+}
 
+function getRequireds(shape: z.ZodRawShape) {
+    const keys: string[] = []
+    for (const key in shape) {
+        const fieldShape = shape[key];
+        if (!(fieldShape instanceof z.ZodDefault)
+            && !(fieldShape instanceof z.ZodOptional))
+            keys.push(key)
+    }
+    return keys;
+}
+
+function parseShape(shape: z.ZodRawShape, paramsArray: Record<string, string[]>, isPartOfUnion = false): Record<string, any> {
+    const parsed: Record<string, any> = {};
+
+    for (const key in shape) {
+        if (shape.hasOwnProperty(key)) {
+            const fieldSchema: z.ZodTypeAny = shape[key];
+            if (paramsArray[key]) {
+                const fieldData = convertToRequiredType(paramsArray[key], fieldSchema)
+
+                if (fieldData.error) {
+                    if (isPartOfUnion)
+                        return {}
+                    continue;
+                }
+                const result = fieldSchema.safeParse(fieldData.data!);
+                if (result.success) parsed[key] = result.data;
+            }
+            else if (fieldSchema instanceof z.ZodDefault) {
+                const result = fieldSchema.safeParse(undefined);
+                if (result.success) parsed[key] = result.data;
+
+            }
+        }
+    }
+
+    return parsed
+}
+
+function getAllParamsAsArrays(searchParams: URLSearchParams): Record<string, string[]> {
+    const params: Record<string, string[]> = {};
+
+    searchParams.forEach((value, key) => {
+        if (!params[key]) {
+            params[key] = [];
+        }
+        params[key].push(value);
+    });
+
+    return params;
+}
+
+function convertToRequiredType(values: string[], schema: z.ZodTypeAny): ParsedData<any> {
+    const usedSchema = getInnerType(schema)
+    if (values.length > 1 && !(usedSchema instanceof z.ZodArray))
+        return { error: "Multiple values for non-array field" }
+    const value = parseValues(usedSchema, values)
+    if (value.error && schema.constructor === z.ZodDefault) {
+        return { data: undefined }
+    }
+    return value;
+}
+
+function parseValues(schema: any, values: string[]): ParsedData<any> {
+    switch (schema.constructor) {
+        case z.ZodNumber: return parseNumber(values[0])
+        case z.ZodBoolean: return parseBoolean(values[0])
+        case z.ZodString: return { data: values[0] }
+        case z.ZodArray: {
+            const elementSchema = schema._def.type;
+            switch (elementSchema.constructor) {
+                case z.ZodNumber: return parseArray(values, parseNumber)
+                case z.ZodBoolean: return parseArray(values, parseBoolean)
+                case z.ZodString: return { data: values };
+                default: return { error: "unsupported array element type " + String(elementSchema.constructor) }
+            }
+        }
+        default: return { error: "unsupported type " + String(schema.constructor) }
+    }
+}
+
+function getInnerType(schema: z.ZodTypeAny) {
+    switch (schema.constructor) {
+        case z.ZodOptional:
+        case z.ZodDefault:
+            return schema._def.innerType
+        default:
+            return schema;
+    }
+}
+
+function parseNumber(str: string): ParsedData<number> {
+    const num = +str
+    return isNaN(num) ? { error: `${str} is NaN` } : { data: num }
+}
+
+function parseBoolean(str: string): ParsedData<boolean> {
+    switch (str) {
+        case "true": return { data: true };
+        case "false": return { data: false };
+        default: return { error: `${str} is not a boolean` };
+    }
+}
+
+function parseArray<T>(values: string[], parseFunction: (str: string) => ParsedData<T>): ParsedData<T[]> {
+    const numbers = values.map(parseFunction)
+    const error = numbers.find(n => n.error)?.error
+    if (error) return { error }
+    return { data: numbers.map(n => n.data!) }
+}

--- a/src/nextjs/init.ts
+++ b/src/nextjs/init.ts
@@ -55,6 +55,12 @@ export async function setup() {
     path.resolve(routes, "./hooks.ts"),
     {}
   );
+  
+  await buildFileFromTemplate(
+    "shared/utils.ts",
+    path.resolve(routes, "./utils.ts"),
+    {}
+  );
 
   spinner.text = "Getting package mananger.";
 


### PR DESCRIPTION
# Introduction

Alrighty!

I tried a couple of ways to convert strings or undefined values into something usable for zod.
* query-string is very limited in what it can do, booleans have to be true, arrays must have at least 2 elements
* fast-querystring has no options and any faint presence of a param either defaults in number 0 or a true boolean, same issue with array
* zod coerce has the same issues as fast-querystring. z.string.transform and z.preprocess make typesafety unusable

The worst part about it is, that the conversion is automatic, not dynamically dependent on the required outcome, which makes a custom parser kinda mandatory...

# Schema

in the current setup, a search object can exist like this
``` typescript
z.object({
    foo: z.array(z.string()),
    bar: z.number().default(12),
    baz: z.boolean().default(true)
})

params = {} // => { bar: 12, baz: true }
```
without triggering any issue if foo isn't provided (the same way we just don't provide a search object in the Link)

Also: if we ever happen to need 2 different paths ( i don't know why i ever came to the conclusion, but it kinda stuck with me)
``` typescript
z.union([
    z.object({
        foo: z.array(z.string()),
        bar: z.number().default(12),
        baz: z.boolean().default(true)
    }),
    z.object({
        qux: z.boolean().optional()
    }),
    z.object({
      quux: z.boolean().default(true)
    })
]),
```


we go through the cases. so if foo has a string provided it gets converted into an array and the whole object will be used (alongside with the default values for bar and baz) because all the required parameters have been provided
``` typescript
params = {foo:"test"} // => { foo: "test", bar: 12, baz: true}
```
if there are no params provided we get an empty object because we automatically set qux as undefined with the optional(), so there is no way to get to check quux.
``` typescript
params = {} // => { } // qux: undefined gets skipped, can be adjusted if requested
```
when we remove the optional from qux, we allow for quux to be populated with the default value of true, because the required parameter qux wasn't assigned.

``` typescript
z.union([
    z.object({
        qux: z.boolean()
    }),
    z.object({
      quux: z.boolean().default(true)
    })
]),
```

``` typescript
params = {} // => { quux: true }
```

# Consumption

``` typescript
import { NextRequest } from "next/server";
import { Route } from "./route.info";
import { safeParseSearchParams } from "@/routes/utils";

export async function GET (request: NextRequest) {
  const searchParams = safeParseSearchParams(Route.search, request.nextUrl.searchParams)
[...]
}
```
## z.object

depending if you either use a single z.object or a selection of use cases (via z.union) there can be different approaches
``` typescript
z.object({
    foo: z.array(z.string()).optional(),
    bar: z.number().default(12),
    baz: z.boolean().default(true)
})
```
In this case you can just destructure your searchParams, like this:
``` typescript
  const {foo, bar, baz} = safeParseSearchParams(Route.search, request.nextUrl.searchParams)
```
## z.union

``` typescript
z.union([
    z.object({
        foo: z.array(z.string()),
        bar: z.number().default(12),
        baz: z.boolean().default(true)
    }),
    z.object({
        qux: z.boolean().optional()
    }),
    z.object({
      quux: z.boolean().default(true)
    })
]),
```
For the union approach there is one more step required:
``` typescript
  const searchParams = safeParseSearchParams(Route.search, request.nextUrl.searchParams)
  if ("foo" in searchParams) {
    const { foo, bar, baz } = searchParams
  }
```

depending on how complex the handling of the params needs to be we can also check for a secondary parameter:

``` typescript
z.union([
    z.object({
        foo: z.array(z.string()),
        bar: z.number(),
    }),
    z.object({
        foo: z.array(z.string()),
        baz: z.boolean(),
    })
]),
```

``` typescript
  const searchParams = safeParseSearchParams(Route.search, request.nextUrl.searchParams)
  if ("bar" in searchParams) {
    const { foo, bar } = searchParams
  }
```
But to be honest, the whole union setup is designed for edge-cases as in this case it would make more sense to have foo as a routing parameter (aka the [[...foo]] folder in Next.js)

# Supported Types

Right now we only Support ZodString, ZodBoolean, ZodNumber, their respective ZodArrays, ZodOptional and ZodDefault
however you can always add and manage the handling of your Types in the @/routes/utils file.

# Customizability

since there are different use cases for booleans especially, you can still go change what defaults to true/false in the utils file.

# Last Words
This thing in its entirety is kinda the first draft, there's a lot of stuff that will go from here like: do we really need arrays when NextJs already takes care of that? Do we actually need the union types? those were just random acceptance criteria i set for myself without questioning, it ultimately made me better at zod and gave me a good step up towards releasing my own packages and CLIs so thats a big win ;-)